### PR TITLE
Added 'class' constraint on ILInqProvider and IUnitOfWork interfaces methods

### DIFF
--- a/source/Infrastructure.Domain/ILinqProvider.cs
+++ b/source/Infrastructure.Domain/ILinqProvider.cs
@@ -1,15 +1,18 @@
-using System;
-using System.Linq;
-
 namespace ByndyuSoft.Infrastructure.Domain
 {
-	public interface ILinqProvider
-	{
-		/// <summary>
-		/// Query object for concrete <see cref="IEntity"/>
-		/// </summary>
-		/// <typeparam name="T"><see cref="IEntity"/></typeparam>
-		/// <returns><see cref="IQueryable{T}"/> object for type of T</returns>
-		IQueryable<T> Query<T>();
-	}
+    using System.Linq;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public interface ILinqProvider
+    {
+        /// <summary>
+        ///   Query object for concrete <see cref="IEntity" />
+        /// </summary>
+        /// <typeparam name="TEntity"> <see cref="IEntity" /> </typeparam>
+        /// <returns> <see cref="IQueryable{TEntity}" /> object for type of TEntity </returns>
+        IQueryable<TEntity> Query<TEntity>()
+            where TEntity : class, IEntity;
+    }
 }

--- a/source/Infrastructure.Domain/IQuery.cs
+++ b/source/Infrastructure.Domain/IQuery.cs
@@ -1,20 +1,20 @@
-﻿using JetBrains.Annotations;
-
-namespace ByndyuSoft.Infrastructure.Domain
+﻿namespace ByndyuSoft.Infrastructure.Domain
 {
+    using JetBrains.Annotations;
+
     /// <summary>
-    /// Интерфейс для объектов запросов к базе
+    ///   Интерфейс для объектов запросов к базе
     /// </summary>
-    /// <typeparam name="TCriterion"></typeparam>
-    /// <typeparam name="TResult"></typeparam>
+    /// <typeparam name="TCriterion"> </typeparam>
+    /// <typeparam name="TResult"> </typeparam>
     public interface IQuery<in TCriterion, out TResult>
         where TCriterion : ICriterion
     {
         /// <summary>
-        /// Получить результат из базы
+        ///   Получить результат из базы
         /// </summary>
-        /// <param name="criterion"></param>
-        /// <returns></returns>
+        /// <param name="criterion"> </param>
+        /// <returns> </returns>
         [CanBeNull]
         TResult Ask(TCriterion criterion);
     }

--- a/source/Infrastructure.Domain/IUnitOfWork.cs
+++ b/source/Infrastructure.Domain/IUnitOfWork.cs
@@ -1,25 +1,27 @@
-﻿using System;
-
-namespace ByndyuSoft.Infrastructure.Domain
+﻿namespace ByndyuSoft.Infrastructure.Domain
 {
-	///<summary>
-	/// Единица работы
-	///</summary>
-	public interface IUnitOfWork : IDisposable
-	{
-		///<summary>
-		/// Сохранить ВСЕ изменения в базу
-		///</summary>
-		void Commit();
+    using System;
 
-		/// <summary>
-		/// Пометить сущность для сохранения в базу
-		/// </summary>
-		void Save<TEntity>(TEntity entity) where TEntity : IEntity;
+    ///<summary>
+    ///  Единица работы
+    ///</summary>
+    public interface IUnitOfWork : IDisposable
+    {
+        ///<summary>
+        ///  Сохранить ВСЕ изменения в базу
+        ///</summary>
+        void Commit();
 
-		/// <summary>
-		/// Пометить сущность для удаления из базы
-		/// </summary>
-		void Delete<TEntity>(TEntity entity) where TEntity : IEntity;
-	}
+        /// <summary>
+        ///   Пометить сущность для сохранения в базу
+        /// </summary>
+        void Save<TEntity>(TEntity entity)
+            where TEntity : class, IEntity;
+
+        /// <summary>
+        ///   Пометить сущность для удаления из базы
+        /// </summary>
+        void Delete<TEntity>(TEntity entity)
+            where TEntity : class, IEntity;
+    }
 }

--- a/source/Infrastructure.Domain/IUnitOfWorkFactory.cs
+++ b/source/Infrastructure.Domain/IUnitOfWorkFactory.cs
@@ -1,23 +1,23 @@
-﻿using System;
-using System.Data;
-
-namespace ByndyuSoft.Infrastructure.Domain
+﻿namespace ByndyuSoft.Infrastructure.Domain
 {
-	///<summary>
-	/// Фабрика uow
-	///</summary>
-	public interface IUnitOfWorkFactory
-	{
-	    ///<summary>
-		/// Создает uow, если у uow не будет вызван метод <see cref="IUnitOfWork.Commit"/>, то автоматически будет выполнен rollback
-		///</summary>
-		///<param name="isolationLevel"></param>
-		///<returns></returns>
-		IUnitOfWork Create(IsolationLevel isolationLevel);
-		///<summary>
-		/// Создает uow, если у uow не будет вызван метод <see cref="IUnitOfWork.Commit"/>, то автоматически будет выполнен rollback
-		///</summary>
-		///<returns></returns>
-		IUnitOfWork Create();
-	}
+    using System.Data;
+
+    ///<summary>
+    ///  Фабрика uow
+    ///</summary>
+    public interface IUnitOfWorkFactory
+    {
+        ///<summary>
+        ///  Создает uow, если у uow не будет вызван метод <see cref="IUnitOfWork.Commit" />, то автоматически будет выполнен rollback
+        ///</summary>
+        ///<param name="isolationLevel"> </param>
+        ///<returns> </returns>
+        IUnitOfWork Create(IsolationLevel isolationLevel);
+
+        ///<summary>
+        ///  Создает uow, если у uow не будет вызван метод <see cref="IUnitOfWork.Commit" />, то автоматически будет выполнен rollback
+        ///</summary>
+        ///<returns> </returns>
+        IUnitOfWork Create();
+    }
 }

--- a/source/Infrastructure.NHibernate/LinqQueryBase.cs
+++ b/source/Infrastructure.NHibernate/LinqQueryBase.cs
@@ -2,21 +2,33 @@
 {
     using System.Linq;
     using Domain;
+    using JetBrains.Annotations;
 
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <typeparam name="TEntity"></typeparam>
+    /// <typeparam name="TCriterion"></typeparam>
+    /// <typeparam name="TResult"></typeparam>
+    [PublicAPI]
     public abstract class LinqQueryBase<TEntity, TCriterion, TResult> : IQuery<TCriterion, TResult>
         where TCriterion : ICriterion
-        where TEntity : IEntity
+        where TEntity : class, IEntity
     {
-        private readonly ILinqProvider linq;
+        private readonly ILinqProvider _linq;
 
         protected LinqQueryBase(ILinqProvider linq)
         {
-            this.linq = linq;
+            _linq = linq;
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        [PublicAPI]
         public virtual IQueryable<TEntity> Query
         {
-            get { return linq.Query<TEntity>(); }
+            get { return _linq.Query<TEntity>(); }
         }
 
         public abstract TResult Ask(TCriterion criterion);

--- a/source/Infrastructure.NHibernate/NHibernateLinqProvider.cs
+++ b/source/Infrastructure.NHibernate/NHibernateLinqProvider.cs
@@ -1,22 +1,35 @@
-using System;
-using System.Linq;
-using ByndyuSoft.Infrastructure.Domain;
-using NHibernate.Linq;
-
 namespace ByndyuSoft.Infrastructure.NHibernate
 {
-	public class NHibernateLinqProvider : ILinqProvider
-	{
-		private readonly ISessionProvider sessionProvider;
+    using System.Linq;
+    using Domain;
+    using JetBrains.Annotations;
+    using global::NHibernate.Linq;
 
-		public NHibernateLinqProvider(ISessionProvider sessionProvider)
-		{
-			this.sessionProvider = sessionProvider;
-		}
+    /// <summary>
+    /// 
+    /// </summary>
+    [PublicAPI]
+    public class NHibernateLinqProvider : ILinqProvider
+    {
+        private readonly ISessionProvider _sessionProvider;
 
-		public IQueryable<T> Query<T>()
-		{
-			return sessionProvider.CurrentSession.Query<T>();
-		}
-	}
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="sessionProvider"></param>
+        public NHibernateLinqProvider(ISessionProvider sessionProvider)
+        {
+            _sessionProvider = sessionProvider;
+        }
+
+        #region ILinqProvider Members
+
+        public IQueryable<TEntity> Query<TEntity>()
+            where TEntity : class, IEntity
+        {
+            return _sessionProvider.CurrentSession.Query<TEntity>();
+        }
+
+        #endregion
+    }
 }

--- a/source/Infrastructure.NHibernate/NHibernateUnitOfWork.cs
+++ b/source/Infrastructure.NHibernate/NHibernateUnitOfWork.cs
@@ -1,51 +1,57 @@
-﻿using System;
-using System.Data;
-using ByndyuSoft.Infrastructure.Domain;
-using NHibernate;
-using NHibernate.Context;
-
-namespace ByndyuSoft.Infrastructure.NHibernate
+﻿namespace ByndyuSoft.Infrastructure.NHibernate
 {
-	internal class NHibernateUnitOfWork : IUnitOfWork
-	{
-		private readonly ISession session;
-	    private ITransaction transaction;
+    using System;
+    using System.Data;
+    using Domain;
+    using global::NHibernate;
+    using global::NHibernate.Context;
 
-	    public void Dispose()
-		{
-		    if (!transaction.WasCommitted && !transaction.WasRolledBack)
-		        transaction.Rollback();
-		    transaction.Dispose();
-			transaction = null;
+    internal class NHibernateUnitOfWork : IUnitOfWork
+    {
+        private readonly ISession _session;
+        private ITransaction _transaction;
 
-			CurrentSessionContext.Unbind(session.SessionFactory);
-			session.Dispose();
-		}
-
-		public void Commit()
-		{
-			transaction.Commit();
-		}
-
-		public void Save<TEntity>(TEntity entity) where TEntity : IEntity
-		{
-			session.Save(entity);
-		}
-
-		public void Delete<TEntity>(TEntity entity) where TEntity : IEntity
-		{
-			session.Delete(entity);
-		}
-
-	    public NHibernateUnitOfWork(ISession session, IsolationLevel isolationLevel = IsolationLevel.ReadCommitted) 
-	    {
+        public NHibernateUnitOfWork(ISession session, IsolationLevel isolationLevel = IsolationLevel.ReadCommitted)
+        {
             if (session == null)
                 throw new ArgumentNullException("session");
 
             CurrentSessionContext.Bind(session);
 
-            this.session = session;
-            transaction = session.BeginTransaction(isolationLevel);
-	    }
-	}
+            _session = session;
+            _transaction = session.BeginTransaction(isolationLevel);
+        }
+
+        #region IUnitOfWork Members
+
+        public void Dispose()
+        {
+            if (!_transaction.WasCommitted && !_transaction.WasRolledBack)
+                _transaction.Rollback();
+            _transaction.Dispose();
+            _transaction = null;
+
+            CurrentSessionContext.Unbind(_session.SessionFactory);
+            _session.Dispose();
+        }
+
+        public void Commit()
+        {
+            _transaction.Commit();
+        }
+
+        public void Save<TEntity>(TEntity entity)
+            where TEntity : class, IEntity
+        {
+            _session.Save(entity);
+        }
+
+        public void Delete<TEntity>(TEntity entity)
+            where TEntity : class, IEntity
+        {
+            _session.Delete(entity);
+        }
+
+        #endregion
+    }
 }

--- a/source/Infrastructure.NHibernate/NHibernateUnitOfWorkFactory.cs
+++ b/source/Infrastructure.NHibernate/NHibernateUnitOfWorkFactory.cs
@@ -1,33 +1,39 @@
-﻿using System;
-using System.Data;
-using ByndyuSoft.Infrastructure.Domain;
-using NHibernate;
-
-namespace ByndyuSoft.Infrastructure.NHibernate
+﻿namespace ByndyuSoft.Infrastructure.NHibernate
 {
-	///<summary>
-	///</summary>
-	public class NHibernateUnitOfWorkFactory : IUnitOfWorkFactory
-	{
-		private readonly ISessionFactory sessionSessionFactory;
+    using System.Data;
+    using Domain;
+    using JetBrains.Annotations;
+    using global::NHibernate;
 
-		///<summary>
-		/// ctor
-		///</summary>
-		///<param name="sessionFactory"></param>
-		public NHibernateUnitOfWorkFactory(ISessionFactory sessionFactory)
-		{
-			sessionSessionFactory = sessionFactory;
-		}
+    ///<summary>
+    /// 
+    ///</summary>
+    [PublicAPI]
+    public class NHibernateUnitOfWorkFactory : IUnitOfWorkFactory
+    {
+        private readonly ISessionFactory _sessionSessionFactory;
 
-	    public IUnitOfWork Create(IsolationLevel isolationLevel)
-	    {
-	        return new NHibernateUnitOfWork(sessionSessionFactory.OpenSession(), isolationLevel);
-	    }
+        ///<summary>
+        ///  ctor
+        ///</summary>
+        ///<param name="sessionFactory"> </param>
+        public NHibernateUnitOfWorkFactory(ISessionFactory sessionFactory)
+        {
+            _sessionSessionFactory = sessionFactory;
+        }
 
-		public IUnitOfWork Create()
-		{
-			return Create(IsolationLevel.ReadCommitted);
-		}
-	}
+        #region IUnitOfWorkFactory Members
+
+        public IUnitOfWork Create(IsolationLevel isolationLevel)
+        {
+            return new NHibernateUnitOfWork(_sessionSessionFactory.OpenSession(), isolationLevel);
+        }
+
+        public IUnitOfWork Create()
+        {
+            return Create(IsolationLevel.ReadCommitted);
+        }
+
+        #endregion
+    }
 }


### PR DESCRIPTION
I've added 'class' constraint on ILInqProvider and IUnitOfWork interfaces methods since it's natural for parameters of those methods to be classes (not struct types) because they're expected to be a entity.
